### PR TITLE
modify image classification codes to adapt ce pipeline

### DIFF
--- a/paddle/infer/image_classification/CMakeLists.txt
+++ b/paddle/infer/image_classification/CMakeLists.txt
@@ -47,14 +47,14 @@ link_directories("${PADDLE_LIB}/paddle/lib")
 
 
 if(WITH_MKL)
-    include_directories("${PADDLE_LIB}/third_party/install/mklml/lib")
+    include_directories("${PADDLE_LIB}/third_party/install/mklml/include")
     set(MATH_LIB ${PADDLE_LIB}/third_party/install/mklml/lib/libmklml_intel${CMAKE_SHARED_LIBRARY_SUFFIX} 
     ${PADDLE_LIB}/third_party/install/mklml/lib/libiomp5${CMAKE_SHARED_LIBRARY_SUFFIX})
-set(MKLDNN_PATH "{PADDLE_LIB}/third_party/install/mkldnn")
-if(EXISTS ${MKLDNN_PATH})
-    include_directories("${MKLDNN_PATH}/include")
-    set(MKLDNN_LIB ${MKLDNN_PATH}/lib/libmkldnn.so.0)
-endif()
+    set(MKLDNN_PATH "{PADDLE_LIB}/third_party/install/mkldnn")
+    if(EXISTS ${MKLDNN_PATH})
+        include_directories("${MKLDNN_PATH}/include")
+        set(MKLDNN_LIB ${MKLDNN_PATH}/lib/libmkldnn.so.0)
+    endif()
 else()
 set(MATH_LIB ${PADDLE_LIB}/third_party/install/openblas/lib/libopenblas${CMAKE_STATIC_LIBRARY_SUFFIX})
 endif()
@@ -67,7 +67,7 @@ endif()
 
 
 set(EXTERNAL_LIB "-lrt -ldl -lpthread")
-set(DEPS ${DEPS} ${MATH_LIB} ${MKLDNN_LIB} glog gflags protobuf xxhash ${EXTERNAL_LIB})
+set(DEPS ${DEPS} ${MATH_LIB} ${MKLDNN_LIB} glog gflags xxhash ${EXTERNAL_LIB})
 
 if(WITH_GPU)
     if(USE_TENSORRT)
@@ -75,7 +75,7 @@ if(WITH_GPU)
         set(DEPS ${DEPS} ${TENSORRT_ROOT}/lib/libnvinfer_plugin${CMAKE_SHARED_LIBRARY_SUFFIX})
     endif()
     set(DEPS ${DEPS} ${CUDA_LIB}/libcudart${CMAKE_SHARED_LIBRARY_SUFFIX})
-    set(DEPS ${DEPS} ${CUDNN_LIB}/libcublas${CMAKE_SHARED_LIBRARY_SUFFIX})
+    set(DEPS ${DEPS} ${CUDA_LIB}/libcublas${CMAKE_SHARED_LIBRARY_SUFFIX})
     set(DEPS ${DEPS} ${CUDNN_LIB}/libcudnn${CMAKE_SHARED_LIBRARY_SUFFIX})
 endif()
 

--- a/paddle/infer/image_classification/image_classification.cc
+++ b/paddle/infer/image_classification/image_classification.cc
@@ -27,7 +27,7 @@ namespace paddle_infer{
     }
 
     void PrepareTRTConfig(Config *config){
-        config->SetModel(FLAGS_dirname + "/model", FLAGS_dirname + "/params");
+        config->SetModel(FLAGS_dirname + "/x.pdmodel", FLAGS_dirname + "/x.pdiparams");
         if(FLAGS_use_gpu){
             config->EnableUseGpu(1000, 0); // gpu:0
         }else{
@@ -36,7 +36,7 @@ namespace paddle_infer{
         }
         
         config->SwitchUseFeedFetchOps(false);
-        config->SwitchIrOptim(false);  // close all optimization
+        config->SwitchIrOptim(true);  // close all optimization
     }
 
 
@@ -55,7 +55,8 @@ namespace paddle_infer{
         int height = 224;
         int width = 224;
         int input_num = channels * height * width * batch_size;
-        float input[input_num] = {0};
+        float input[input_num];
+        memset(input, 0, input_num*sizeof(float) );
 
         // 4. feed data
         auto input_names = predictor->GetInputNames();

--- a/paddle/infer/image_classification/re_build.sh
+++ b/paddle/infer/image_classification/re_build.sh
@@ -2,13 +2,30 @@
 
 WITH_MKL=ON
 export WITH_GPU=ON
-USET_TENSORRT=OFF
+USE_TENSORRT=OFF
 
-CUDA_LIB_DIR='/usr/local/cuda-10.1/lib64/'
-CUDNN_LIB_DIR='/usr/lib/x86_64-linux-gnu/'
+if [[ -z "${PADDLE_LIB_DIR}" ]]; then
+  echo -e "\033[33m ====> {PADDLE_LIB_DIR} is undefined, set to default value \033[0m";
+  LIB_DIR='/workspace/code_dev/paddle-fork/build_infer_10/paddle_inference_install_dir';
+else
+  LIB_DIR=${PADDLE_LIB_DIR};
+fi
+
+if [[ -z "${CUDA_LIB_DIR}" ]]; then
+  echo -e "\033[33m ====> {CUDA_LIB_DIR} is undefined, set to default value \033[0m";
+  CUDA_LIB_DIR='/usr/local/cuda-10.1/lib64/';
+fi
+
+if [[ -z "${CUDNN_LIB_DIR}" ]]; then
+  echo -e "\033[33m ====> {CUDNN_LIB_DIR} is undefined, set to default value \033[0m";
+  CUDNN_LIB_DIR='/usr/lib/x86_64-linux-gnu/';
+fi
+
 # please modify LIB_DIR for your built inference lib dir
 # TODO: Need discuss with QA to determine how to config this env vaiable
-LIB_DIR='/workspace/code_dev/paddle-fork/build_infer_10/paddle_inference_install_dir'
+echo -e "\033[33m ====> LIB_DIR : ${LIB_DIR} \033[0m"
+echo -e "\033[33m ====> CUDA_LIB_DIR : ${CUDA_LIB_DIR} \033[0m"
+echo -e "\033[33m ====> CUDNN_LIB_DIR : ${CUDNN_LIB_DIR} \033[0m"
 
 mkdir -p build
 cd build
@@ -23,4 +40,4 @@ cmake .. -DPADDLE_LIB=${LIB_DIR} \
   -DCUDNN_LIB=${CUDNN_LIB_DIR}
 
 make -j4
-mv image_classification_exe ../
+


### PR DESCRIPTION
修改内容：
1. `CMakeLists` 调整了下格式，移出了protobuf，libcublas.so 查找路径更改了下
2. `image_classification.cc` 更改了下读取的模型名，打开了预测优化
3. `re_build.sh` 里更改了环境变量的传入方式（方便在CE里配置）

TODO:
1. CMakeLists 存在一个问题，编译带mkldnn的lib时，链接时会挂如下图，暂未修复
![image](https://user-images.githubusercontent.com/14963836/99234631-bdee0a00-282f-11eb-982f-26acb3e11999.png)

